### PR TITLE
Add: 유저 정보(이메일, 닉네임, 수신 동의, 운, 목표) 등록

### DIFF
--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
-import { CheckDataDTO } from "../dto/userDTO";
+import { CheckDataDTO, CreateDataDTO } from "../dto/userDTO";
 import { DuplicateException, EmptyException } from "../middlewares/exceptions";
+import { regExpCheck } from "../middlewares/regexpCheck";
 import userService from "../services/users";
 
 
@@ -13,8 +14,21 @@ const checkEmail = async (req: Request, res: Response) => {
   else { return res.status(200).json({ message: "Available" }); }
 }
 
+const createUserInfo = async (req: Request, res: Response) => {
+  const data: CreateDataDTO = req.body;
+  if(!(data.email && data.nickname && data.email && data.fortune_id && data.goals )) {
+    throw new EmptyException("Input_Error"); }
+  
+  let regExpResult = regExpCheck(data);
+
+  if(regExpResult) { 
+    await userService.createUserInfo(data);
+    return res.status(201).json({ message : "User_Created" }) }
+}
+
 
 
 export default {
-  checkEmail
+  checkEmail,
+  createUserInfo
 }

--- a/src/dto/userDTO.ts
+++ b/src/dto/userDTO.ts
@@ -2,8 +2,24 @@ export interface CheckDataDTO {
   email: string
 }
 
+export interface CreateDataDTO {
+  nickname: string,
+  email: string,
+  fortune_id: string,
+  opt_in: boolean,
+  goals: string[]
+}
 
 export interface ReturnDataDTO {
   id: number,
   email: string
+}
+
+export interface UpdateDataDTO {
+  nickname: string,
+  email: string,
+  fortune_id: string,
+  opt_in: boolean,
+  image?: string,
+  goals: string[]
 }

--- a/src/middlewares/exceptions.ts
+++ b/src/middlewares/exceptions.ts
@@ -15,10 +15,26 @@ export class EmptyException extends BadRequestException {
   }
 }
 
+export class RegExpException extends BadRequestException {
+
+  constructor(message: string) {
+    super(400, message)
+    this.name = "RegExp Validate Exception"
+  }
+}
+
 export class DuplicateException extends BadRequestException {
 
   constructor(message: string) {
     super(409, message)
     this.name = "Duplicate Exception"
+  }
+}
+
+export class NotFoundException extends BadRequestException {
+
+  constructor(message: string) {
+    super(404, message)
+    this.name = "Not Found Exception"
   }
 }

--- a/src/middlewares/regexpCheck.ts
+++ b/src/middlewares/regexpCheck.ts
@@ -1,0 +1,16 @@
+import { CreateDataDTO } from "../dto/userDTO";
+import { RegExpException } from "./exceptions";
+
+
+
+export const regExpCheck = (data: CreateDataDTO) => {
+  const nicknameRegExp = /^[0-9a-zA-Z-ㄱ-힣-\{\}\[\]\/?.,;:|\)*~`!^\-_+<>@\#$%&\\\=\(\'\" ]{1,8}$/g;
+  const emailRegExp =
+      /([\w-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([\w-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$/;
+  
+  const nicknameResult = nicknameRegExp.test(data.nickname)
+  const emailResult = emailRegExp.test(data.email)
+
+  if( nicknameResult && emailResult ) { return true; }
+  else { throw new RegExpException("RegExp_Error"); }
+}

--- a/src/models/users.ts
+++ b/src/models/users.ts
@@ -1,6 +1,9 @@
-import { dataSource } from "../configs/typeorm.config"
-import { ReturnDataDTO } from "../dto/userDTO";
+import { dataSource } from "../configs/typeorm.config";
+import { QueryRunner } from "typeorm";
+import { CreateDataDTO, UpdateDataDTO, ReturnDataDTO } from "../dto/userDTO";
 import { Users } from "../entities/users.entity";
+import { Goals } from "../entities/goals.entity";
+import { BadRequestException, EmptyException } from "../middlewares/exceptions";
 
 
 
@@ -11,8 +14,104 @@ const getEmails = async (): Promise<ReturnDataDTO[]> => {
   .getRawMany()
 }
 
+const createUser = async (data: CreateDataDTO): Promise<void> => {
+  if(data.goals.length < 0) { throw new EmptyException("Input_Error"); }
+  if(data.goals.length > 5) { throw new BadRequestException(400, "Bad_Request"); }
+
+  const queryRunner: QueryRunner = dataSource.createQueryRunner();
+
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
+
+  try {
+    let values: string = ``
+    const insertId = await insertUser(data);
+    data.goals.forEach((el, i) => {
+      values += `(${insertId}, "${el}")`;
+      if(i < data.goals.length-1) { values += ","; }
+    })
+    await insertGoals(values);
+    await queryRunner.commitTransaction();
+  } catch (err) {
+    await queryRunner.rollbackTransaction();
+    throw new Error("Internal Server Error");
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+const insertUser = async(data: CreateDataDTO): Promise<number> => {
+  const result = await dataSource.createQueryBuilder()
+    .insert()
+    .into(Users)
+    .values({
+      nickname: data.nickname,
+      email: data.email,
+      fortune_id: +data.fortune_id,
+      opt_in: data.opt_in
+    })
+    .execute()
+
+  return result.raw.insertId;
+}
+
+const insertGoals = async (values: string) => {
+  return await dataSource.query(`
+      INSERT INTO goals(user_id, goal)
+      VALUES ${values}
+  `)
+}
+
+const updateGoals = async (userId: number, data: UpdateDataDTO) => {
+  if(data.goals.length < 0) { throw new EmptyException("Input_Error"); }
+  if(data.goals.length > 5) { throw new BadRequestException(400, "Bad_Request"); }
+  
+  const queryRunner: QueryRunner = dataSource.createQueryRunner();
+
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
+
+  try {
+    await updateUserInfo(userId, data);
+    await dataSource.createQueryBuilder()
+    .delete()
+    .from(Goals)
+    .where("user_id = :userId", {userId})
+    .execute()
+    
+    let values: string = ``
+    
+    data.goals.forEach((el, i) => {
+      values += `(${userId}, "${el}")`;
+      if(i < data.goals.length-1) { values += ","; }
+    })
+    await insertGoals(values);
+    await queryRunner.commitTransaction();
+  } catch (err) {
+    await queryRunner.rollbackTransaction();
+    throw new Error("Internal Server Error");
+  } finally {
+    await queryRunner.release();
+  }
+}
+
+const updateUserInfo = async (userId: number, data: UpdateDataDTO) => {
+  await dataSource.createQueryBuilder()
+  .update(Users)
+  .set({
+    nickname: data.nickname,
+    fortune_id: +data.fortune_id,
+    opt_in: data.opt_in,
+    image: data.image
+  })
+  .where("id = :userId", { userId })
+  .execute()
+}
+
 
 
 export default {
-  getEmails
+  getEmails,
+  createUser,
+  updateGoals
 }

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -5,6 +5,7 @@ import { asyncWrap } from "../middlewares/asyncWrap";
 const router = express.Router()
 
 router.post("/check", asyncWrap(userController.checkEmail))
+router.post("/registration", asyncWrap(userController.createUserInfo))
 
 
 export default router

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,9 +1,23 @@
-import { CheckDataDTO } from "../dto/userDTO";
 import userDao from "../models/users";
 import CryptoJS from "crypto-js";
+import { CheckDataDTO, CreateDataDTO } from "../dto/userDTO";
+
 
 
 const key: any = process.env.KEY
+
+const getFortuneIdByName = (fortune: string | undefined) => {
+  let fortuneId: number;
+  
+  switch (fortune) {
+    case "love" : return fortuneId = 1
+    case "money" : return fortuneId = 2
+    case "relationship" : return fortuneId = 3
+    case "ego" : return fortuneId = 4
+    case "health" : return fortuneId = 5
+  }
+}
+
 
 const checkEmail = async (data: CheckDataDTO) => {
   let result: { idx: number; res: string | boolean } = { idx: 0, res: "" }
@@ -24,8 +38,29 @@ const checkEmail = async (data: CheckDataDTO) => {
   return result;
 }
 
+const createUserInfo = async (data: CreateDataDTO) => {
+  const fortuneId = getFortuneIdByName(data.fortune_id)
+  if(fortuneId !== undefined) { data.fortune_id = fortuneId.toString(); }
+  
+  const foundUser = await checkEmail(data);
+  if(foundUser.res) { 
+    await userDao.updateGoals(foundUser.idx, data);
+  }
+  else if(!foundUser.res) {
+    const encryptEmail = CryptoJS.AES.encrypt(data.email, CryptoJS.enc.Utf8.parse(key), {
+      iv: CryptoJS.enc.Utf8.parse(""),
+      padding: CryptoJS.pad.Pkcs7,
+      mode: CryptoJS.mode.CBC
+    }).toString()
+    
+    data.email = encryptEmail;
+    await userDao.createUser(data);
+  }
+}
+
 
 
 export default {
-  checkEmail
+  checkEmail,
+  createUserInfo
 }


### PR DESCRIPTION
유저 정보(이메일, 닉네임, 수신 동의, 운, 목표) 등록
  - 유저가 입력한 정보 등록
  - email, nickname, fortune_id, goals 필수 값이 전달되지 않는 경우 예외 처리
  - 등록할 email, nickname을 정규표현식으로 검증
  - 문자열로 전달된 fortune_id를 getFortuneIdByName 함수를 통해 매칭되는 idx 값으로 변환
  - checkEmail을 통해 기존에 이용했던 유저라면 updateGoals로 분기 처리
  - 이미 Goals에 있던 목표를 delete 후 새로운 목표 insert
  - Goals 값들은 data 나열로 한번에 insert 하기 위해 values 쿼리문을 작성하는 반복문 사용
  - 유저 정보 등록으로 Goals, Users 각각의 테이블에 변동사항 있을 때, 원자성을 위해 transaction 사용