### PR TITLE
Add: 유저 목표 이미지 등록

### DIFF
--- a/src/controllers/users.ts
+++ b/src/controllers/users.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { CheckDataDTO, CreateDataDTO } from "../dto/userDTO";
+import { CheckDataDTO, CreateDataDTO, UpdateDataDTO } from "../dto/userDTO";
 import { DuplicateException, EmptyException } from "../middlewares/exceptions";
 import { regExpCheck } from "../middlewares/regexpCheck";
 import userService from "../services/users";
@@ -26,9 +26,18 @@ const createUserInfo = async (req: Request, res: Response) => {
     return res.status(201).json({ message : "User_Created" }) }
 }
 
+const updateUserImage = async (req: Request, res: Response) => {
+  const data: UpdateDataDTO = req.body;
+  if(!(data.email && data.image)) { throw new EmptyException("Input_Error"); }
+
+  await userService.updateUserImage(data);
+  return res.status(200).json({ message : "Req_Success" })
+}
+
 
 
 export default {
   checkEmail,
-  createUserInfo
+  createUserInfo,
+  updateUserImage
 }

--- a/src/models/users.ts
+++ b/src/models/users.ts
@@ -108,10 +108,21 @@ const updateUserInfo = async (userId: number, data: UpdateDataDTO) => {
   .execute()
 }
 
+const updateUserImage = async (userId: number, data: UpdateDataDTO) => {
+  await dataSource.createQueryBuilder()
+  .update(Users)
+  .set({
+    image: data.image
+  })
+  .where("id = :userId", { userId })
+  .execute()
+}
+
 
 
 export default {
   getEmails,
   createUser,
-  updateGoals
+  updateGoals,
+  updateUserImage
 }

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -6,6 +6,7 @@ const router = express.Router()
 
 router.post("/check", asyncWrap(userController.checkEmail))
 router.post("/registration", asyncWrap(userController.createUserInfo))
+router.post("/image", asyncWrap(userController.updateUserImage))
 
 
 export default router

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -1,6 +1,7 @@
 import userDao from "../models/users";
 import CryptoJS from "crypto-js";
-import { CheckDataDTO, CreateDataDTO } from "../dto/userDTO";
+import { CheckDataDTO, CreateDataDTO, UpdateDataDTO } from "../dto/userDTO";
+import { NotFoundException } from "../middlewares/exceptions"
 
 
 
@@ -58,9 +59,19 @@ const createUserInfo = async (data: CreateDataDTO) => {
   }
 }
 
+const updateUserImage = async (data: UpdateDataDTO) => {
+  const foundUser = await checkEmail(data)
+
+  if(foundUser.res) { 
+    await userDao.updateUserImage(foundUser.idx, data);
+  }
+  else if(!foundUser.res) { throw new NotFoundException("User_Not_Found"); }
+}
+
 
 
 export default {
   checkEmail,
-  createUserInfo
+  createUserInfo,
+  updateUserImage
 }


### PR DESCRIPTION
유저 목표 이미지 등록
  - 유저가 목표까지 다 작성한 후, 최종 페이지에서 만들어진 목표 이미지를 DB에 저장
  - email, image 필수 값 미입력 시 예외 처리
  - 유저 email 체크 후 존재하지 않는 유저의 경우 분기, 예외 처리
  - 존재하는 유저의 idx 값을 인자로 함께 전달, idx 값이 일치하는 Users에 image update